### PR TITLE
Added global owners to repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ashblue @zsteiner


### PR DESCRIPTION
A quick GitHub trick that will auto tag Ash and Zack whenever a new PR is created.